### PR TITLE
Better container support for linux web apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ Better container support for linux web apps
     - Variable descriptions clarify valid container and non-container values for `fx` 
     - Setting the `fx` variable to `compose` or `kube` triggers base64 encode of `fx_version` variable
     - Set default value for storage_accounts variable 
+    - Add ip_restrictions support in site_config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+[Unreleased]
+
+[v1.5.0] - 2020-01-13
+
+Better container support for linux web apps
+
+    - Variable descriptions clarify valid container and non-container values for `fx` 
+    - Setting the `fx` variable to `compose` or `kube` triggers base64 encode of `fx_version` variable
+    - Set default value for storage_accounts variable 

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ resource "azurerm_app_service" "app" {
     always_on        = "true"
     app_command_line = var.command
     php_version      = var.win_php_version
+    ip_restriction   = local.ip_restrictions
     linux_fx_version = local.linux_fx_version
     http2_enabled    = var.http2_enabled
     ftps_state       = var.ftps_state

--- a/main.tf
+++ b/main.tf
@@ -39,11 +39,18 @@ resource "azurerm_app_service" "app" {
     always_on        = "true"
     app_command_line = var.command
     php_version      = var.win_php_version
-    ip_restriction   = local.ip_restrictions
     linux_fx_version = local.linux_fx_version
     http2_enabled    = var.http2_enabled
     ftps_state       = var.ftps_state
 
+    dynamic "ip_restriction" {
+      for_each = var.ip_restrictions
+      content {
+        ip_address  = split("/", ip_restriction.value)[0]
+        subnet_mask = cidrnetmask(ip_restriction.value)
+      }
+    }
+  
     default_documents = [
       "index.html",
       "index.php",

--- a/slot.tf
+++ b/slot.tf
@@ -32,6 +32,14 @@ resource "azurerm_app_service_slot" "app" {
     http2_enabled    = var.http2_enabled
     ftps_state       = var.ftps_state
 
+    dynamic "ip_restriction" {
+      for_each = var.ip_restrictions
+      content {
+        ip_address  = split("/", ip_restriction.value)[0]
+        subnet_mask = cidrnetmask(ip_restriction.value)
+      }
+    }
+  
     default_documents = [
       "index.html",
       "index.php",

--- a/test/fixture/containers.tf
+++ b/test/fixture/containers.tf
@@ -1,0 +1,39 @@
+module "docker_appservice" {
+  source              = "../.."
+  rg_name             = basename(module.rg.id)
+  rgid                = var.rgid
+  environment         = var.environment
+  location            = var.location
+  name_prefix         = format("%s0", random_string.test.result)
+  num                 = 1
+  slot_num            = var.slot_num
+  plan                = azurerm_app_service_plan.linux.id
+  subscription_id     = var.subscription_id
+  http2_enabled       = var.http2_enabled
+  key_vault_id        = "" # azurerm_key_vault_secret.test.key_vault_id # see main.tf too
+  secret_name         = "" # var.secret_name
+  fx                  = "docker"
+  fx_version          = "appsvcsample/python-helloworld:latest"
+}
+
+module "compose_appservice" {
+  source              = "../.."
+  rg_name             = basename(module.rg.id)
+  rgid                = var.rgid
+  environment         = var.environment
+  location            = var.location
+  name_prefix         = format("%s1", random_string.test.result)
+  num                 = 1
+  slot_num            = var.slot_num
+  plan                = azurerm_app_service_plan.linux.id
+  subscription_id     = var.subscription_id
+  http2_enabled       = var.http2_enabled
+  key_vault_id        = "" # azurerm_key_vault_secret.test.key_vault_id # see main.tf too
+  secret_name         = "" # var.secret_name
+  fx                  = "compose"
+  fx_version          = data.local_file.compose.content
+}
+
+data "local_file" "compose" {
+    filename = format("%s/docker-compose.yml", path.module)
+}

--- a/test/fixture/containers.tf
+++ b/test/fixture/containers.tf
@@ -1,39 +1,41 @@
 module "docker_appservice" {
-  source              = "../.."
-  rg_name             = basename(module.rg.id)
-  rgid                = var.rgid
-  environment         = var.environment
-  location            = var.location
-  name_prefix         = format("%s0", random_string.test.result)
-  num                 = 1
-  slot_num            = var.slot_num
-  plan                = azurerm_app_service_plan.linux.id
-  subscription_id     = var.subscription_id
-  http2_enabled       = var.http2_enabled
-  key_vault_id        = "" # azurerm_key_vault_secret.test.key_vault_id # see main.tf too
-  secret_name         = "" # var.secret_name
-  fx                  = "docker"
-  fx_version          = "appsvcsample/python-helloworld:latest"
+  source          = "../.."
+  rg_name         = basename(module.rg.id)
+  rgid            = var.rgid
+  environment     = var.environment
+  location        = var.location
+  name_prefix     = format("%s0", random_string.test.result)
+  num             = 1
+  slot_num        = var.slot_num
+  plan            = azurerm_app_service_plan.linux.id
+  subscription_id = var.subscription_id
+  http2_enabled   = var.http2_enabled
+  key_vault_id    = "" # azurerm_key_vault_secret.test.key_vault_id # see main.tf too
+  secret_name     = "" # var.secret_name
+  fx              = "docker"
+  fx_version      = "appsvcsample/python-helloworld:latest"
+  ip_restrictions = var.ip_restrictions
 }
 
 module "compose_appservice" {
-  source              = "../.."
-  rg_name             = basename(module.rg.id)
-  rgid                = var.rgid
-  environment         = var.environment
-  location            = var.location
-  name_prefix         = format("%s1", random_string.test.result)
-  num                 = 1
-  slot_num            = var.slot_num
-  plan                = azurerm_app_service_plan.linux.id
-  subscription_id     = var.subscription_id
-  http2_enabled       = var.http2_enabled
-  key_vault_id        = "" # azurerm_key_vault_secret.test.key_vault_id # see main.tf too
-  secret_name         = "" # var.secret_name
-  fx                  = "compose"
-  fx_version          = data.local_file.compose.content
+  source          = "../.."
+  rg_name         = basename(module.rg.id)
+  rgid            = var.rgid
+  environment     = var.environment
+  location        = var.location
+  name_prefix     = format("%s1", random_string.test.result)
+  num             = 1
+  slot_num        = var.slot_num
+  plan            = azurerm_app_service_plan.linux.id
+  subscription_id = var.subscription_id
+  http2_enabled   = var.http2_enabled
+  key_vault_id    = "" # azurerm_key_vault_secret.test.key_vault_id # see main.tf too
+  secret_name     = "" # var.secret_name
+  fx              = "compose"
+  fx_version      = data.local_file.compose.content
+  ip_restrictions = var.ip_restrictions
 }
 
 data "local_file" "compose" {
-    filename = format("%s/docker-compose.yml", path.module)
+  filename = format("%s/docker-compose.yml", path.module)
 }

--- a/test/fixture/docker-compose.yml
+++ b/test/fixture/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.3'
+
+services:
+   db:
+     image: mysql:5.7
+     volumes:
+       - db_data:/var/lib/mysql
+     restart: always
+     environment:
+       MYSQL_ROOT_PASSWORD: somewordpress
+       MYSQL_DATABASE: wordpress
+       MYSQL_USER: wordpress
+       MYSQL_PASSWORD: wordpress
+
+   wordpress:
+     depends_on:
+       - db
+     image: wordpress:latest
+     ports:
+       - "8000:80"
+     restart: always
+     environment:
+       WORDPRESS_DB_HOST: db:3306
+       WORDPRESS_DB_USER: wordpress
+       WORDPRESS_DB_PASSWORD: wordpress
+       WORDPRESS_DB_NAME: wordpress
+volumes:
+    db_data: {} 

--- a/test/fixture/linux.tf
+++ b/test/fixture/linux.tf
@@ -17,6 +17,7 @@ module "linux_appservice" {
   rgid                = var.rgid
   environment         = var.environment
   location            = var.location
+  name_prefix         = format("%s2", random_string.test.result)
   num                 = 1
   slot_num            = var.slot_num
   plan                = azurerm_app_service_plan.linux.id

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -12,11 +12,11 @@ resource "random_string" "test" {
 provider "azurerm" {
   subscription_id = var.subscription_id
   tenant_id       = var.tenant_id
-  version         = "~> 1.35.0"
+  version         = "~> 1.40.0"
 }
 
 provider "azuread" {
-  version = "~> 0.6.0"
+  version = "~> 0.7.0"
 }
 
 module "rg" {

--- a/test/fixture/terraform.tfvars
+++ b/test/fixture/terraform.tfvars
@@ -5,3 +5,6 @@ location            = "westus"
 create_date         = "20301011"
 slot_num            = 1
 secret_name         = "testsecret"
+ip_restrictions     = ["192.168.0.0/16", "172.16.0.0/12"]
+tenant_id           = "ADD_TENANT_ID_TO_TEST"
+subscription_id     = "ADD_SUBSCRIPTION_ID_TO_TEST"

--- a/test/fixture/variables.tf
+++ b/test/fixture/variables.tf
@@ -27,3 +27,7 @@ variable "azure_registry_name" {
 variable "azure_registry_rg" {
   default = ""
 }
+
+variable "ip_restrictions" {
+  default = []
+}

--- a/test/fixture/windows.tf
+++ b/test/fixture/windows.tf
@@ -17,6 +17,7 @@ module "windows_appservice" {
   rgid            = format("win%s", var.rgid)
   environment     = var.environment
   location        = var.location
+  name_prefix     = format("%s3", random_string.test.result)
   num             = 1
   slot_num        = var.slot_num
   plan            = azurerm_app_service_plan.windows.id

--- a/test/fixture/windows.tf
+++ b/test/fixture/windows.tf
@@ -25,6 +25,7 @@ module "windows_appservice" {
   http2_enabled   = var.http2_enabled
   key_vault_id    = "" # azurerm_key_vault_secret.test.key_vault_id # see main.tf too
   secret_name     = "" # var.secret_name
+  ip_restrictions = var.ip_restrictions
 
   storage_accounts = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "http2_enabled" {
 variable "ip_restrictions" {
   type        = list(string)
   default     = []
-  description = "A list of IP addresses in CIDR format specifying Access Restrictions."
+  description = "A list of IP addresses in CIDR format that will be permitted access to the site.  All other IP addresses will be denied.  If you do not specify this variable, or if you specify an empty list, all IP addresses will be permitted."
 }
 
 variable "ftps_state" {
@@ -219,13 +219,6 @@ locals {
     for secret in data.azurerm_key_vault_secret.app:
     replace(secret.name, "-", "_") => format("@Microsoft.KeyVault(SecretUri=%s)", secret.id)
   } : {}
-
-  ip_restrictions = [
-    for prefix in var.ip_restrictions : {
-      ip_address  = split("/", prefix)[0]
-      subnet_mask = cidrnetmask(prefix)
-    }
-  ]
 }
 
 # This module provides a data map output to lookup naming standard references

--- a/variables.tf
+++ b/variables.tf
@@ -45,27 +45,18 @@ variable "rg_name" {
   description = "Resource group name"
 }
 
-variable "fx" {
-  default     = "PHP"
-  description = "Used for Linux web app framework selection - ignored on Windows web apps.  Default is PHP. Valid options are shown in the templates at https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/app-service."
-}
-
-variable "fx_version" {
-  default     = "7.2"
-  description = "Used for Linux web app framework selection - ignored on Windows web apps.  Valid values refer to PHP or NodeJS version, or can specify a Docker hub path and version tag."
-}
-
-variable "win_php_version" {
-  default     = "7.2"
-  description = "Used to select Windows web app PHP version.  Valid values are 5.6, 7.0, 7.1, or 7.2.  Default is 7.2."
-}
-
 variable "subscription_id" {
   description = "Prompt for subscription ID"
 }
 
 variable "http2_enabled" {
   description = "Is HTTP2 Enabled on this App Service? Defaults to false."
+}
+
+variable "ip_restrictions" {
+  type        = list(string)
+  default     = []
+  description = "A list of IP addresses in CIDR format specifying Access Restrictions."
 }
 
 variable "ftps_state" {
@@ -95,6 +86,21 @@ variable "secret_name" {
   type        = string
   default     = ""
   description = "Secret name to retrieve from var.key_vault_id. Uses Key Vault references as values for app settings."
+}
+
+variable "win_php_version" {
+  default     = "7.2"
+  description = "Used to select Windows web app PHP version.  Valid values are 5.6, 7.0, 7.1, or 7.2.  Default is 7.2."
+}
+
+variable "fx" {
+  default     = "php"
+  description = "Used for Linux web app framework selection - ignored on Windows web apps. Default is PHP. Valid values for non-container deployments are `php` or `node`. Valid values for container deployments are: `docker`, `compose` or `kube`."
+}
+
+variable "fx_version" {
+  default     = "7.2"
+  description = "Used for Linux web app framework selection - ignored on Windows web apps.  Valid values are dependent on the `fx` variable value. If `fx` is `php`, `fx_value` would need to be a supported Azure web app PHP version (ie: 5.6, 7.0, 7.2). Similar if `fx` is `node`. If `fx` is `docker`, `fx_version` should specify a valid container image name such as `appsvcsample/python-helloworld:latest`. Lastly, if `fx` is either `compose` or `kube`, `fx_version` should be a valid YAML configuration."
 }
 
 variable "port" {
@@ -154,6 +160,8 @@ variable "storage_accounts" {
     access_key   = string
     mount_path   = string
   }))
+  default     = []
+  description = "Used for Azure Linux web app Bring Your Own storage. Mounts an Azure Blob container or Azure Files share to a specific folder path on the web app."
 }
 
 variable "tags" {
@@ -179,8 +187,6 @@ locals {
   name_prefix = var.name_prefix != "" ? var.name_prefix : local.default_name_prefix
   name        = format("%s%s", local.name_prefix, local.type)
 
-  linux_fx_version = data.azurerm_app_service_plan.app.kind == "Windows" ? null : format("%s%s", var.fx, var.fx_version)
-
   docker_registry_url  = var.docker_registry_url != "" ? var.docker_registry_url : var.azure_registry_name != "" && var.azure_registry_rg != "" ? data.azurerm_container_registry.acr[0].login_server : ""
   docker_registry_username  = var.docker_registry_username != "" ? var.docker_registry_username : var.azure_registry_name != "" && var.azure_registry_rg != "" ? data.azurerm_container_registry.acr[0].admin_username : ""
   docker_registry_password  = var.docker_registry_password != "" ? var.docker_registry_password : var.azure_registry_name != "" && var.azure_registry_rg != "" ? data.azurerm_container_registry.acr[0].admin_password : ""
@@ -194,10 +200,32 @@ locals {
     "DOCKER_REGISTRY_SERVER_PASSWORD"     = local.docker_registry_password
   }
 
+  fx = upper(var.fx)
+
+  supported_fx = {
+    COMPOSE = true
+    DOCKER  = true
+    KUBE    = true
+    NODE    = true
+    PHP     = true
+  }
+  check_supported_fx = local.supported_fx[local.fx]
+  
+  fx_version = local.fx == "COMPOSE" || local.fx == "KUBE" ? base64encode(var.fx_version) : var.fx_version
+
+  linux_fx_version = data.azurerm_app_service_plan.app.kind == "Windows" ? null : format("%s|%s", local.fx, local.fx_version)
+
   secure_app_settings = var.secret_name != "" && var.key_vault_id != "" ? {
     for secret in data.azurerm_key_vault_secret.app:
     replace(secret.name, "-", "_") => format("@Microsoft.KeyVault(SecretUri=%s)", secret.id)
   } : {}
+
+  ip_restrictions = [
+    for prefix in var.ip_restrictions : {
+      ip_address  = split("/", prefix)[0]
+      subnet_mask = cidrnetmask(prefix)
+    }
+  ]
 }
 
 # This module provides a data map output to lookup naming standard references


### PR DESCRIPTION
    - Variable descriptions clarify valid container and non-container values for `fx` 
    - Setting the `fx` variable to `compose` or `kube` triggers base64 encode of `fx_version` variable
    - Set default value for storage_accounts variable 
    - Add ip_restrictions support in site_config