### PR TITLE
Version 1.6.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,17 +72,8 @@ resource "azurerm_role_assignment" "WebsiteContributor" {
   principal_id         = azuread_group.WebsiteContributor.id
 }
 
-# Used to work around BadRequest error if linux_fx_version is not empty on a
-# Windows app service plan
-provider "azurerm" {
-  alias           = "plan"
-  subscription_id = split("/", var.plan)[2]
-  tenant_id       = data.azurerm_client_config.current.tenant_id
-}
-
 # Should support using plans in a different subscription from web app
 data "azurerm_app_service_plan" "app" {
-  provider            = azurerm.plan
   name                = local.plan_name
   resource_group_name = local.plan_rg
 }

--- a/variables.tf
+++ b/variables.tf
@@ -205,7 +205,7 @@ locals {
 # Otherwise, format proper key vault reference
   secure_app_settings = {
     for k, v in var.secure_app_settings_refs :
-    replace(k, "/[^a-zA-Z0-9_]/", "_") => format("@Microsoft.KeyVault(SecretUri=%s)", v) 
+    replace(k, "/[^a-zA-Z0-9-]/", "-") => format("@Microsoft.KeyVault(SecretUri=%s)", v) 
     if length(regexall("https://([A-Za-z][0-9A-Za-z-_]+)\\.vault\\.azure\\.net/secrets/([A-Za-z0-9-]{1,127})/(\\w{32})", v)) > 0
   } 
 }


### PR DESCRIPTION
   - Fix incorrect naming restriction for app settings
   - Remove support for cross-subscription plans

The cross-subscription idea wasn't accounting for use_msi in the aliased provider.